### PR TITLE
[Generate.sh] Skip test when mpv fails

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -60,6 +60,11 @@ fi
 echo -e "# ${imgbase^}" > ${imgbase^}.md
 
 for scaler in $scalers; do
+  mpv --no-config --use-text-osd=yes $img --title="scaler_test" --geometry=$geometry -vo opengl-hq:dither-depth=8:scale=$scaler:cscale=$scaler:dscale=$scaler > /dev/null
+  if [ $? -ne 0 ]; then
+	  echo "mpv failed. Skipping test"
+	  continue
+  fi
   (mpv --no-config --use-text-osd=yes --pause $img --title="scaler_test" --geometry=$geometry -vo opengl-hq:dither-depth=8:scale=$scaler:cscale=$scaler:dscale=$scaler) &
   id=$!
   sleep $stime


### PR DESCRIPTION
This pull request prevents the script from taking screenshots if mpv failed to start. 
